### PR TITLE
Optimize x86_64 and others

### DIFF
--- a/user/openmandriva/macros
+++ b/user/openmandriva/macros
@@ -114,7 +114,7 @@ Provides:	%{1} = %{?2}%{!?2:%{EVRD}} \
 %Werror_cflags -Wformat -Werror=format-security
 
 %_ssp_cflags -fstack-protector-strong --param=ssp-buffer-size=4 %{?_serverbuild_flags}
-%__common_cflags -Os %{debugcflags} -pipe %{Werror_cflags} %{?_fortify_cflags}
+%__common_cflags -Os %{debugcflags} -pipe %{Werror_cflags} %{?_fortify_cflags} -ffunction-sections -fdata-sections
 %__common_cflags_with_ssp %{__common_cflags} %{?_ssp_cflags}
 
 # Servers opt flags.
@@ -285,7 +285,7 @@ fi
 
 %__libtoolize_configure %{?__libtoolize:(cd $CONFIGURE_TOP; [ ! -f configure.in -a ! -f configure.ac ] || %{__libtoolize} --copy --force)}
 
-%ldflags %{optflags} -Wl,-O2 %{?!_disable_ld_no_undefined: -Wl,--no-undefined} %{?!_disable_lto:-flto} %{?_hardened_flags}
+%ldflags %{optflags} -Wl,-O2 %{?!_disable_ld_no_undefined: -Wl,--no-undefined} %{?!_disable_lto:-flto} %{?_hardened_flags} -Wl,--gc-sections
 
 %setup_compile_flags \
   CC="${CC:-%__cc}" ; export CC ; \

--- a/user/openmandriva/rpmrc
+++ b/user/openmandriva/rpmrc
@@ -24,7 +24,7 @@ optflags: mipsel %{?__common_cflags:%{__common_cflags} -march=mips3 -mtune=loong
 optflags: ppc -O2 -g -m32 %{?!_disable_lto:-flto}
 optflags: ppc64 -O2 -g -m64 -mminimal-toc %{?!_disable_lto:-flto}
 
-optflags: x86_64 %{?__common_cflags_with_ssp:%{__common_cflags_with_ssp} -fPIC}%{!?__common_cflags_with_ssp:-O2 -g -m64 -mtune=generic} %{?!_disable_lto:-flto}
+optflags: x86_64 %{?__common_cflags_with_ssp:%{__common_cflags_with_ssp} -fPIC}%{!?__common_cflags_with_ssp:-O2 -g -m64 -mtune=generic} -mmmx -msse2 -msse3 -msse4.1 -msse4.2 %{?!_disable_lto:-flto}
 
 #############################################################
 # For a given uname().machine, the default build arch


### PR DESCRIPTION
1. -ffunction-sections -fdata-sections and -Wl,--gc-sections may help in reduce binary size
https://elinux.org/Function_sections

2. Enable SSE3 and SSE4 on x86_64. Processors with these instructions are available for 10+ years
march=x86_64 does not enable SSE3/4 by default
