### PR TITLE
Restore CFLAGS in LDFLAGS

### DIFF
--- a/user/openmandriva/macros
+++ b/user/openmandriva/macros
@@ -107,7 +107,9 @@ Provides:	%{1} = %{?2}%{!?2:%{EVRD}} \
 # the corresponding variable names.
 %build_fflags %{optflags} -I%{_fmoddir}
 
-%build_ldflags -Wl,-O2 %{?!_disable_ld_no_undefined: -Wl,--no-undefined} %{?!_disable_lto:-flto} %{?_hardened_flags}
+# When LTOing, it is useful to duplicate CFLAGS in LDFALGS
+# See https://github.com/OpenMandrivaSoftware/rpm-openmandriva-setup/pull/3
+%build_ldflags %{optflags} -Wl,-O2 %{?!_disable_ld_no_undefined: -Wl,--no-undefined} %{?!_disable_lto:-flto} %{?_hardened_flags}
 
 # Deprecated names.  For backwards compatibility only.
 %ldflags %build_ldflags


### PR DESCRIPTION
See discussion in https://github.com/OpenMandrivaSoftware/rpm-openmandriva-setup/pull/3
Fixes: 8bf22e9 ("Remove CFLAGS from LDFLAGS")

I do not like this duplication, but don't know a better solution right now.