### PR TITLE
Remove extra space from optflags

### DIFF
--- a/user/openmandriva/macros
+++ b/user/openmandriva/macros
@@ -154,7 +154,7 @@ Provides:	%{1} = %{?2}%{!?2:%{EVRD}} \
 # cf http://wiki.mandriva.com/en/Development/Packaging/Problems#format_not_a_string_literal_and_no_format_arguments
 %Werror_cflags -Wformat -Werror=format-security
 
-%_ssp_cflags -fstack-protector-strong --param=ssp-buffer-size=4 %{?_serverbuild_flags: %_serverbuild_flags}
+%_ssp_cflags -fstack-protector-strong --param=ssp-buffer-size=4%{?_serverbuild_flags: %_serverbuild_flags}
 %__common_cflags -Os -fomit-frame-pointer %{debugcflags} -pipe %{Werror_cflags} %{?_fortify_cflags}
 %__common_cflags_with_ssp %{__common_cflags} %{?_ssp_cflags}
 


### PR DESCRIPTION
Without %_serverbuild_flags
CFLAGS='-O2 -fomit-frame-pointer -gdwarf-4 -Wstrict-aliasing=2 -pipe -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -fPIC -fstack-protector-strong --param=ssp-buffer-size=4  -m64 -mtune=generic '

With %_serverbuild_flags
CFLAGS='-O2 -fomit-frame-pointer -gdwarf-4 -Wstrict-aliasing=2 -pipe -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -fPIC -fstack-protector-strong --param=ssp-buffer-size=4  -fstack-protector-all -m64 -mtune=generic '

----

From liblo's configure.ac: 

```
# Filter out -Werror temporarily, otherwise library checks can fail
CFLAGS_nowerror="`echo $CFLAGS | sed 's/-Werror\([^=]\|$\)//'`"
if test "$CFLAGS" = "$CFLAGS_nowerror"; then
  CFLAGS_werror=
else
  CFLAGS_werror=" -Werror"
  CFLAGS="$CFLAGS_nowerror"
fi
```

----

Extra space after --param=ssp-buffer-size=4 breaks the test. And "-Werror" is added ("restored" by mistake).