### PR TITLE
Rosa sync 1

### DIFF
--- a/build/fileattrs/kmod.attr
+++ b/build/fileattrs/kmod.attr
@@ -1,2 +1,2 @@
 %__kmod_provides	%{_rpmconfigdir}/openmandriva/kmod-deps.sh -P
-%__kmod_path		^.*(/lib/modules/|/var/lib/dkms/).*\.ko(\.gz|\.xz)?$
+%__kmod_path		^.*(/lib/modules/.*\.ko(\.gz|\.xz)?|/var/lib/dkms(-binary)?|/usr/src/.*/dkms.conf)$

--- a/build/macros.d/macros.python
+++ b/build/macros.d/macros.python
@@ -57,3 +57,18 @@ BuildRequires: %{__python} %{-d:python-devel}
 
 # Enable python bytecompilation
 %_python_bytecompile_build 1
+
+# For migration from packages names "python-foo" to "python2-foo"
+%py2_migration_meta() \
+%define py2_migration_rn %(echo %{1} | sed -e 's,^python2-,python-,g' | grep '^python-') \
+%{expand:\
+Provides: %{py2_migration_rn} = %{EVRD} \
+Conflicts: %{py2_migration_rn} < %{EVRD} \
+Obsoletes: %{py2_migration_rn} < %{EVRD} \
+}
+
+# rosa2019.1+ names packages as python2-foo
+# rosa2016.1 names them as python-foo
+# Allow to name as %%python2-foo
+%python2 python2
+

--- a/build/macros.d/macros.python
+++ b/build/macros.d/macros.python
@@ -45,21 +45,8 @@ find %1 -name '*.pyo' -exec rm -f {} \\; \
   sleep 1
 }
 
-%py3_build %py_build
-
 %py_install() %{expand:\\\
   CFLAGS="%{optflags}" %{__python} %{py_setup} %{?py_setup_args} install -O1 --skip-build --root %{buildroot} %{?*}
-}
-
-%py3_install %py_install
-
-%py2_build() %{expand:\\\
-  CFLAGS="%{optflags}" %{__python2} %{py_setup} %{?py_setup_args} build --executable="%{__python2} %{py_shbang_opts}" %{?*}
-  sleep 1
-}
-
-%py2_install() %{expand:\\\
-  CFLAGS="%{optflags}" %{__python2} %{py_setup} %{?py_setup_args} install -O1 --skip-build --root %{buildroot} %{?*}
 }
 
 %py_requires(d) \

--- a/build/macros.d/macros.python
+++ b/build/macros.d/macros.python
@@ -72,3 +72,47 @@ Obsoletes: %{py2_migration_rn} < %{EVRD} \
 # Allow to name as %%python2-foo
 %python2 python2
 
+# From Fedora
+# Macro to replace overly complicated references to PyPI source files.
+# Expands to the pythonhosted URL for a package
+# Accepts zero to three arguments:
+# 1:  The PyPI project name, defaulting to %srcname if it is defined, then
+#     %pypi_name if it is defined, then just %name.
+# 2:  The PYPI version, defaulting to %version.
+# 3:  The file extension, defaulting to "tar.gz".  (A period will be added
+#     automatically.)
+# Requires %__pypi_url and %__pypi_default_extension to be defined.
+%__pypi_url https://files.pythonhosted.org/packages/source/
+%__pypi_default_extension tar.gz
+%pypi_source() %{lua:
+    local src = rpm.expand('%1')
+    local ver = rpm.expand('%2')
+    local ext = rpm.expand('%3')
+    local url = rpm.expand('%__pypi_url')
+\
+    -- If no first argument, try %srcname, then %pypi_name, then %name
+    -- Note that rpm leaves macros unchanged if they are not defined.
+    if src == '%1' then
+        src = rpm.expand('%srcname')
+    end
+    if src == '%srcname' then
+        src = rpm.expand('%pypi_name')
+    end
+    if src == '%pypi_name' then
+        src = rpm.expand('%name')
+    end
+\
+    -- If no second argument, use %version
+    if ver == '%2' then
+        ver = rpm.expand('%version')
+    end
+\
+    -- If no third argument, use the preset default extension
+    if ext == '%3' then
+        ext = rpm.expand('%__pypi_default_extension')
+    end
+\
+    local first = string.sub(src, 1, 1)
+\
+    print(url .. first .. '/' .. src .. '/' .. src .. '-' .. ver .. '.' .. ext)
+}

--- a/user/openmandriva/macros
+++ b/user/openmandriva/macros
@@ -16,6 +16,7 @@
 
 # mdvbz#64914
 %_rpmgio .ufdio
+%_rpmhome %getconfdir
 
 %__urlgetfile(url, dest) wget %1 -O %2 || (rm -f %2 && exit 1)
 

--- a/user/openmandriva/macros
+++ b/user/openmandriva/macros
@@ -48,6 +48,10 @@ Provides:	%{1} = %{?2}%{!?2:%{EVRD}} \
   echo "warning: %%makeinstall_std is deprecated, try %%make_install instead" 1>&2\
   make DESTDIR=%{?buildroot:%{buildroot}} install INSTALL="install -p"
 
+%apply_patches \
+  echo "warning: %%apply_patches is deprecated, try %%autopatch -p[01] instead" 1>&2\
+  %{autopatch -p1}
+
 %__lua %{_bindir}/lua
 %__rc %{_bindir}/rc
 %__xar %{_bindir}/xar

--- a/user/openmandriva/macros
+++ b/user/openmandriva/macros
@@ -49,6 +49,8 @@ Provides:	%{1} = %{?2}%{!?2:%{EVRD}} \
   echo "warning: %%makeinstall_std is deprecated, try %%make_install instead" 1>&2\
   make DESTDIR=%{?buildroot:%{buildroot}} install INSTALL="install -p"
 
+%makeinstall_qt	make INSTALL_ROOT=%{?buildroot:%{buildroot}} install STRIP=true
+
 %apply_patches \
   echo "warning: %%apply_patches is deprecated, try %%autopatch -p[01] instead" 1>&2\
   %{autopatch -p1}

--- a/user/openmandriva/macros
+++ b/user/openmandriva/macros
@@ -257,6 +257,9 @@ export CFLAGS="%{optflags} -fPIE"; export CXXFLAGS="%{optflags} -fPIE"; export R
 # For Appdata metainfo
 %_metainfodir %{_datadir}/metainfo
 
+# For backwards compatibility
+%_appdatadir %{_metainfodir}
+
 #==============================================================================
 # ---- Build configuration macros.
 #


### PR DESCRIPTION
Let's try to sync ROSA and OMV where possible.

This PR includes patches from https://abf.io/import/rpm-openmandriva-setup/tree/rosa2019.1 which can be merged to upstream to my mind.

It will help to continue using rpm-openmandriva-setup in rosa and avoid making a fork due too many patches.